### PR TITLE
feat: Add Lic2 and checkValidAngle functions with corresponding tests

### DIFF
--- a/src/main/java/org/dd2480/Main.java
+++ b/src/main/java/org/dd2480/Main.java
@@ -279,8 +279,8 @@ public class Main {
      * @param point1 The first point.
      * @param point2 The second point, which is the vertex of the angle.
      * @param point3 The third point.
-     * @param epsilon The tolerance for the angle difference. Must be in the range [0, π].
-     * @return True if the angle is valid (not within epsilon of π), False otherwise.
+     * @param epsilon The tolerance for the angle difference. Must be in the range [0, π).
+     * @return True if the angle is valid (bigger than pi + epsilon or smaller than pi - epsilon), False otherwise.
      * @throws IllegalArgumentException If any of the points is null.
      */
     public static boolean checkValidAngle(Point2D point1,Point2D point2,Point2D point3,double epsilon){
@@ -289,7 +289,7 @@ public class Main {
         }
         double angle = calculateAngle(point1,point2,point3);
         if (angle != -1){
-            return !(Math.abs(angle - Math.PI) < epsilon);
+            return !(Math.abs(angle - Math.PI) <= epsilon);
         }
         return false;
     }

--- a/src/main/java/org/dd2480/Main.java
+++ b/src/main/java/org/dd2480/Main.java
@@ -76,6 +76,30 @@ public class Main {
 
     /**
      *
+     * Function that corresponds to LIC 2
+     *
+     * @param points array of points
+     * @param epsilon deviation from PI in LIC # 2 & 9
+     * @return true if there exists at least one set of three consecutive data points
+     * which form an angle that is not in the range of epsilon from pi
+     * @throws IllegalArgumentException if epsilon is not in the range: [0,pi]
+     *
+     */
+
+    public static boolean lic2(Point2D[] points, double epsilon){
+        if (epsilon<0 || epsilon>Math.PI){
+            throw new IllegalArgumentException("Invalid input for epsilon.");
+        }
+        for (int i=0; i<points.length -2; i++){
+            if (checkValidAngle(points[i],points[i+1],points[i+2],epsilon)){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     *
      * Function that corresponds to LIC 4
      *
      * @param points array of points
@@ -247,6 +271,27 @@ public class Main {
             cosAngle = -1;
         }
         return Math.acos(cosAngle);
+    }
+    /**
+     * Checks whether the angle formed by three given points
+     * is not within the specified epsilon of a straight angle (π radians).
+     *
+     * @param point1 The first point.
+     * @param point2 The second point, which is the vertex of the angle.
+     * @param point3 The third point.
+     * @param epsilon The tolerance for the angle difference. Must be in the range [0, π].
+     * @return True if the angle is valid (not within epsilon of π), False otherwise.
+     * @throws IllegalArgumentException If any of the points is null.
+     */
+    public static boolean checkValidAngle(Point2D point1,Point2D point2,Point2D point3,double epsilon){
+        if (point1 == null || point2 == null || point3 == null){
+            throw new IllegalArgumentException("Points cannot be null.");
+        }
+        double angle = calculateAngle(point1,point2,point3);
+        if (angle != -1){
+            return !(Math.abs(angle - Math.PI) < epsilon);
+        }
+        return false;
     }
 
 

--- a/src/test/java/org/dd2480/Lic2Test.java
+++ b/src/test/java/org/dd2480/Lic2Test.java
@@ -11,6 +11,8 @@ class Lic2Test {
 
     @Test
     void shouldThrowIllegalArgumentException_whenEpsilonNegative() {
+        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
+        Main.numPoints = 3;
         // Test when epsilon negative
         assertThrows(IllegalArgumentException.class, () -> {
             Main.lic2(Main.points,-0.1); // Epsilon should be in the range [0, Math.PI]
@@ -18,6 +20,8 @@ class Lic2Test {
     }
     @Test
     void shouldThrowIllegalArgumentException_whenEpsilonGreaterThanPi() {
+        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
+        Main.numPoints = 3;
         // Test with epsilon greater than Math.PI
         assertThrows(IllegalArgumentException.class, () -> {
             Main.lic2(Main.points,Math.PI + 0.1); // Epsilon should be in the range [0, Math.PI]

--- a/src/test/java/org/dd2480/Lic2Test.java
+++ b/src/test/java/org/dd2480/Lic2Test.java
@@ -6,7 +6,6 @@ import java.awt.geom.Point2D;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 class Lic2Test {
 
     @Test

--- a/src/test/java/org/dd2480/Lic2Test.java
+++ b/src/test/java/org/dd2480/Lic2Test.java
@@ -6,6 +6,7 @@ import java.awt.geom.Point2D;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+
 class Lic2Test {
 
     @Test

--- a/src/test/java/org/dd2480/Lic2Test.java
+++ b/src/test/java/org/dd2480/Lic2Test.java
@@ -1,0 +1,36 @@
+package org.dd2480;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Point2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Lic2Test {
+
+    @Test
+    void shouldThrowIllegalArgumentException_whenEpsilonNegative() {
+        // Test when epsilon negative
+        assertThrows(IllegalArgumentException.class, () -> {
+            Main.lic2(Main.points,-0.1); // Epsilon should be in the range [0, Math.PI]
+        });
+    }
+    @Test
+    void shouldThrowIllegalArgumentException_whenEpsilonGreaterThanPi() {
+        // Test with epsilon greater than Math.PI
+        assertThrows(IllegalArgumentException.class, () -> {
+            Main.lic2(Main.points,Math.PI + 0.1); // Epsilon should be in the range [0, Math.PI]
+        });
+    }
+    @Test
+    void shouldReturnTrueValue_whenValidEpsilon() {
+        // Test with a valid epsilon value
+        // Assuming numPoints and points are set up correctly
+        Point2D[] points = {
+                new Point2D.Double(0, 0),
+                new Point2D.Double(1, 0),
+                new Point2D.Double(1, 1)
+        };
+        assertTrue(Main.lic2(points,Math.PI / 10)); // Valid epsilon
+    }
+}

--- a/src/test/java/org/dd2480/ValidAngleTest.java
+++ b/src/test/java/org/dd2480/ValidAngleTest.java
@@ -33,5 +33,21 @@ class ValidAngleTest {
 
         assertFalse(Main.checkValidAngle(point1, point2, point3, Math.PI)); // Should be false since angle is close to Pi
     }
+    @Test
+    void shouldReturnFalse_whenAngleIsPIMinusEpsilon(){
+        Point2D point1 = new Point2D.Double(1, 0);
+        Point2D point2 = new Point2D.Double(0, 0);
+        Point2D point3 = new Point2D.Double(0, 1);
+
+        assertFalse(Main.checkValidAngle(point1,point2,point3,Math.PI/2));
+    }
+    @Test
+    void shouldReturnFalse_whenAngleIsPIPlusEpsilon(){
+        Point2D point1 = new Point2D.Double(1, 0);
+        Point2D point2 = new Point2D.Double(0, 0);
+        Point2D point3 = new Point2D.Double(-1, -1);
+
+        assertFalse(Main.checkValidAngle(point1,point2,point3,Math.PI/4));
+    }
 
 }

--- a/src/test/java/org/dd2480/ValidAngleTest.java
+++ b/src/test/java/org/dd2480/ValidAngleTest.java
@@ -1,0 +1,37 @@
+package org.dd2480;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Point2D;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidAngleTest {
+
+    @Test
+    void shouldThrowIllegalArgumentException_whenNullPointGiven() {
+        // Test with null point1
+        assertThrows(IllegalArgumentException.class, () -> {
+            Main.checkValidAngle(null, new Point2D.Double(1, 1), new Point2D.Double(2, 2), Math.PI / 10);
+        });
+    }
+    @Test
+    void shouldReturnTrue_whenGivenValidPoints() {
+        // Test with valid points
+        Point2D point1 = new Point2D.Double(0, 0);
+        Point2D point2 = new Point2D.Double(1, 0);
+        Point2D point3 = new Point2D.Double(1, 1);
+
+        assertTrue(Main.checkValidAngle(point1, point2, point3, Math.PI / 10)); // Valid points and epsilon
+    }
+    @Test
+    void shouldReturnFalse_whenGivenInvalidAngle() {
+        // Test where angle is within epsilon range of pi
+        Point2D point1 = new Point2D.Double(0, 0);
+        Point2D point2 = new Point2D.Double(1, 0);
+        Point2D point3 = new Point2D.Double(1, 1);
+
+        assertFalse(Main.checkValidAngle(point1, point2, point3, Math.PI)); // Should be false since angle is close to Pi
+    }
+
+}


### PR DESCRIPTION
    - Implement lic2 function to check if there exists at least one set of three consecutive data points forming an angle outside the range (π - EPSILON) to (π + EPSILON).
    - Add checkValidAngle function to validate the angle between three points and ensure it's not within ε of π.
    - Create Lic2Test and ValidAngleTest to cover edge cases and invalid inputs for Lic2 and checkValidAngle.
Closes #27 