### PR TITLE
refactor: Change static variables to parameters

### DIFF
--- a/src/main/java/org/dd2480/Main.java
+++ b/src/main/java/org/dd2480/Main.java
@@ -5,15 +5,6 @@ import java.awt.geom.Point2D;
 public class Main {
 
     /**
-     * NUMPOINTS: The number of planar data points.
-     */
-    public static int numPoints;
-    /**
-     * POINTS: Array containing the coordinates of data points.
-     */
-    public static Point2D[] points;
-
-    /**
      *
      * Checks if a circle can enclose all points. It does this by checking that the
      * distance between every point is less than the diameter of the circle.
@@ -64,11 +55,11 @@ public class Main {
      *         otherwise
      * @throws IllegalArgumentException if radius is negative
      */
-    public static boolean lic1(double radius) {
+    public static boolean lic1(Point2D[] points, double radius) {
         if (radius < 0)
             throw new IllegalArgumentException("Radius must be >= 0");
-        for (int i = 0; i < Main.numPoints - 2; i++)
-            if (!circleContainmentCheck(new Point2D[] { Main.points[i], Main.points[i + 1], Main.points[i + 2] },
+        for (int i = 0; i < points.length - 2; i++)
+            if (!circleContainmentCheck(new Point2D[] { points[i], points[i + 1], points[i + 2] },
                     radius))
                 return true;
         return false;
@@ -131,17 +122,17 @@ public class Main {
      *                                  {@code Main.numPoints} - 3</li>
      *                                  </ul>
      */
-    public static boolean lic8(int aPts, int bPts, double radius) {
+    public static boolean lic8(Point2D[] points, int aPts, int bPts, double radius) {
         if (aPts < 1)
             throw new IllegalArgumentException("A_PTS must be >= 1");
         if (bPts < 1)
             throw new IllegalArgumentException("B_PTS must be >= 1");
-        if (aPts + bPts > Main.numPoints - 3)
+        if (aPts + bPts > points.length - 3)
             throw new IllegalArgumentException("A_PTS + B_PTS must be <= NUMPOINTS - 3");
 
-        for (int i = 0; i < Main.numPoints - 2 - aPts - bPts; i++)
+        for (int i = 0; i < points.length - 2 - aPts - bPts; i++)
             if (!circleContainmentCheck(
-                    new Point2D[] { Main.points[i], Main.points[i + 1 + aPts], Main.points[i + 2 + aPts + bPts] },
+                    new Point2D[] { points[i], points[i + 1 + aPts], points[i + 2 + aPts + bPts] },
                     radius))
                 return true;
         return false;

--- a/src/test/java/org/dd2480/Lic1Test.java
+++ b/src/test/java/org/dd2480/Lic1Test.java
@@ -11,54 +11,48 @@ class Lic1Test {
 
     @Test
     void shouldReturnFalse_whenNoPointsAreGiven() {
-        Main.points = new Point2D[] {};
-        Main.numPoints = 0;
+        Point2D[] points = new Point2D[] {};
 
-        boolean result = Main.lic1(0);
+        boolean result = Main.lic1(points, 0);
         assertEquals(false, result, "there needs to be at least three points to generate a true output");
     }
 
     @Test
     void shouldReturnFalse_whenOnePointIsGiven() {
-        Main.points = new Point2D[] { new Point2D.Double(1, 1) };
-        Main.numPoints = 1;
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1) };
 
-        boolean result = Main.lic1(0);
+        boolean result = Main.lic1(points, 0);
         assertEquals(false, result, "there needs to be at least three points to generate a true output");
     }
 
     @Test
     void shouldReturnFalse_whenTwoPointsAreGiven() {
-        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2)};
-        Main.numPoints = 2;
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2)};
 
-        boolean result = Main.lic1(0);
+        boolean result = Main.lic1(points, 0);
         assertEquals(false, result, "there needs to be at least three points to generate a true output");
     }
 
     @Test
     void shouldThrowIllegalArgumentException_whenRadiusIsNegative() {
-        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
-        Main.numPoints = 3;
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
 
-        assertThrows(IllegalArgumentException.class, () -> Main.lic1(-1), "a negative radius circle cannot exist");
+        assertThrows(IllegalArgumentException.class, () -> Main.lic1(points, -1), "a negative radius circle cannot exist");
     }
 
     @Test
     void shouldReturnTrue_whenThreeConsecutivePointsCannotBeContained() {
-        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
-        Main.numPoints = 3;
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(2, 2), new Point2D.Double(3, 3)};
 
-        boolean result = Main.lic1(1);
+        boolean result = Main.lic1(points, 1);
         assertEquals(true, result, "a 1 radius circle cannot contain both (1, 1) and (3, 3)");
     }
 
     @Test
     void shouldReturnFalse_whenThreeNonConsecutivePointsCannotBeContained() {
-        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(1, 1.5), new Point2D.Double(1, 2), new Point2D.Double(1, 2.5), new Point2D.Double(1, 3)};
-        Main.numPoints = 5;
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(1, 1.5), new Point2D.Double(1, 2), new Point2D.Double(1, 2.5), new Point2D.Double(1, 3)};
 
-        boolean result = Main.lic1(1);
+        boolean result = Main.lic1(points, 1);
         assertEquals(false, result, "the circle should be able to contain all sets of three consecutive points");
     }
 }

--- a/src/test/java/org/dd2480/Lic8Test.java
+++ b/src/test/java/org/dd2480/Lic8Test.java
@@ -12,42 +12,38 @@ class Lic8Test {
     @Test
     void shouldThrowIllegalArgumentException_whenGivenInvalidInputs() {
 
-        Main.points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(-1, -1), new Point2D.Double(0, -1),
+        Point2D[] points = new Point2D[] { new Point2D.Double(1, 1), new Point2D.Double(-1, -1), new Point2D.Double(0, -1),
                 new Point2D.Double(-1, 0) };
-        Main.numPoints = Main.points.length;
 
-        assertThrows(IllegalArgumentException.class, () -> Main.lic8(0, 1, 2),
+        assertThrows(IllegalArgumentException.class, () -> Main.lic8(points, 0, 1, 2),
                 "should throw when A_PTS is < 1");
-        assertThrows(IllegalArgumentException.class, () -> Main.lic8(1, 0, 2),
+        assertThrows(IllegalArgumentException.class, () -> Main.lic8(points, 1, 0, 2),
                 "should throw when B_PTS is < 1");
-        assertThrows(IllegalArgumentException.class, () -> Main.lic8(1, 1, 2),
+        assertThrows(IllegalArgumentException.class, () -> Main.lic8(points, 1, 1, 2),
                 "should throw when A_PTS + B_PTS > (NUMPOINTS - 3)");
     }
 
     @Test
     void shouldReturnTrue_whenThereExistsASetThatCannotBeContained() {
-        Main.points = new Point2D[] { new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
+        Point2D[] points = new Point2D[] { new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
                 new Point2D.Double(0, 3), new Point2D.Double(0, 1), new Point2D.Double(0, 3),  new Point2D.Double(0, 2)};
-        Main.numPoints = Main.points.length;
 
-        assertEquals(true, Main.lic8(1, 1, 0),
+        assertEquals(true, Main.lic8(points, 1, 1, 0),
                 "the set (0, 1), (0, 1), (0, 2) should not be able to be contained");
     }
 
     @Test
     void shouldReturnFalse_whenThereIsNoSetThatCannotBeContained() {
-        Main.points = new Point2D[] { new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
+        Point2D[] points = new Point2D[] { new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
                 new Point2D.Double(0, 3), new Point2D.Double(0, 1) };
-        Main.numPoints = Main.points.length;
 
-        assertEquals(false, Main.lic8(1, 1, 0),
+        assertEquals(false, Main.lic8(points, 1, 1, 0),
                 "should false since the only set of points can be contained");
 
-        Main.points = new Point2D[] { new Point2D.Double(0, 3), new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
+        points = new Point2D[] { new Point2D.Double(0, 3), new Point2D.Double(0, 1), new Point2D.Double(0, 3), new Point2D.Double(0, 1),
                 new Point2D.Double(0, 3), new Point2D.Double(0, 1) };
-        Main.numPoints = Main.points.length;
 
-        assertEquals(false, Main.lic8(1, 1, 0),
+        assertEquals(false, Main.lic8(points, 1, 1, 0),
                 "both of the valid sets should be able to be contained");
     }
 }


### PR DESCRIPTION
Removed static variables `points` and `numPoints` in place of making the points a function parameter.

Affected functions are `lic1` and `lic8`, along with their associated test files.

Closes #22