### PR TITLE
fix: no manifest in jar (#77)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,23 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <source>1.21</source>
+                    <target>1.21</target>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.dd2480.Main</mainClass>                                
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.2</version>
             </plugin>


### PR DESCRIPTION
Fix no manifest in generated jar file by adding appropriate maven plugin.

Closes #77 